### PR TITLE
OpenSSL 4.0 (non-LTS)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     tags:
-      - '3.*.*'
+      - '4.*.*'
     paths-ignore:
       - '.github/workflows/x-*.yml'
   workflow_dispatch: # manually-triggered runs
@@ -25,9 +25,9 @@ jobs:
     name: Build
     runs-on: macos-latest
 
-    env: # use tag version, if available, falling back to 3.6.2 (LTS)
-      OPENSSL_VERSION: "${{ startsWith(github.ref, 'refs/tags/3.') && github.ref_name || '3.6.2' }}"
-      PUBLISH_RELEASE: "${{ startsWith(github.ref, 'refs/tags/3.') && '1' || '0' }}"
+    env: # use tag version, if available, falling back to 4.0.0 (non-LTS)
+      OPENSSL_VERSION: "${{ startsWith(github.ref, 'refs/tags/4.') && github.ref_name || '4.0.0' }}"
+      PUBLISH_RELEASE: "${{ startsWith(github.ref, 'refs/tags/4.') && '1' || '0' }}"
 
     steps:
     - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
     name: Build
     runs-on: macos-latest
 
-    env: # use tag version, if available, falling back to 4.0.0 (non-LTS)
-      OPENSSL_VERSION: "${{ startsWith(github.ref, 'refs/tags/4.') && github.ref_name || '4.0.0' }}"
+    env: # use tag version, if available, falling back to 4.0.1 (non-LTS)
+      OPENSSL_VERSION: "${{ startsWith(github.ref, 'refs/tags/4.') && github.ref_name || '4.0.1' }}"
       PUBLISH_RELEASE: "${{ startsWith(github.ref, 'refs/tags/4.') && '1' || '0' }}"
 
     steps:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-OPENSSL_VERSION_STABLE="4.0.0" # https://github.com/openssl/openssl/releases/tag/openssl-4.0.0
+OPENSSL_VERSION_STABLE="4.0.1" # https://github.com/openssl/openssl/releases/tag/openssl-4.0.1
 IOS_VERSION_MIN="13.4"
 MACOS_VERSION_MIN="11.0"
 CODESIGN_ID="-"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-OPENSSL_VERSION_STABLE="3.6.2" # https://github.com/openssl/openssl/releases/tag/openssl-3.6.2
+OPENSSL_VERSION_STABLE="4.0.0" # https://github.com/openssl/openssl/releases/tag/openssl-4.0.0
 IOS_VERSION_MIN="13.4"
 MACOS_VERSION_MIN="11.0"
 CODESIGN_ID="-"


### PR DESCRIPTION
https://github.com/openssl/openssl/releases/tag/openssl-4.0.0

Note: this is not an LTS version, but it can be tested if desired.